### PR TITLE
Fix onChangeGuides event when zoom prop is set

### DIFF
--- a/packages/react-guides/src/react-guides/Guides.tsx
+++ b/packages/react-guides/src/react-guides/Guides.tsx
@@ -305,7 +305,7 @@ export default class Guides extends React.PureComponent<GuidesProps, GuidesState
         * @param {OnChangeGuides} - Parameters for the changeGuides event
         */
         if (datas.fromRuler) {
-            if (pos >= this.scrollPos && guides.indexOf(guidePos) < 0) {
+            if (guidePos >= this.scrollPos && guides.indexOf(guidePos) < 0) {
                 this.setState({
                     guides: [...guides, guidePos],
                 }, () => {


### PR DESCRIPTION
Ok so we have a bug here where onChangeGuides is not triggering for some cases when zoom prop is set :) 