### PR TITLE
Update Guides.svelte

### DIFF
--- a/packages/svelte-guides/src/Guides.svelte
+++ b/packages/svelte-guides/src/Guides.svelte
@@ -59,7 +59,7 @@
     });
   });
   onDestroy(() => {
-    guides.destroy();
+    if (guides) guides.destroy();
   });
 
   export function getInstance() {


### PR DESCRIPTION
Fix the error shown in sveltekit:

Cannot read properties of undefined (reading 'destroy')
TypeError: Cannot read properties of undefined (reading 'destroy')
    at eval (/node_modules/svelte-guides/src/Guides.svelte:62:10)