### PR TITLE
Added missing Guide Options Properties

### DIFF
--- a/packages/react-guides/src/react-guides/consts.ts
+++ b/packages/react-guides/src/react-guides/consts.ts
@@ -125,6 +125,11 @@ export const PROPERTIES: Array<keyof GuidesOptions> = [
     "guideStyle",
     "guidesOffset",
     "digit",
+    "dragGuideStyle"
+    "displayGuidePos"
+    "guidePosFormat"
+    "guidePosStyle"
+    "lockGuides"
     ...RULER_PROPERTIES,
 ];
 


### PR DESCRIPTION
Added properties that were missing from vue-guides package. Passing those attributes had no effect.